### PR TITLE
Fix placeholder metadata in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "canva-connect"
 version = "0.1.0"
 edition = "2021"
-authors = ["Your Name <your.email@example.com>"]
-description = "A Rust client library for the Canva Connect API"
+authors = ["Triss Healy <triss.healy@canva.com>", "Amp AI Assistant <amp@sourcegraph.com>"]
+description = "A Rust client library for the Canva Connect API. Most code is AI-generated with Amp by Sourcegraph."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/yourusername/canva-connect-rust"
-homepage = "https://github.com/yourusername/canva-connect-rust"
+repository = "https://github.com/trissylegs/canva-connect-rust"
+homepage = "https://github.com/trissylegs/canva-connect-rust"
 documentation = "https://docs.rs/canva-connect"
 keywords = ["canva", "api", "client", "design", "graphics"]
 categories = ["api-bindings", "web-programming::http-client"]


### PR DESCRIPTION
## Summary
Fixes placeholder metadata in Cargo.toml with proper project information.

## Changes Made
- ✅ **Authors**: Updated to include Triss Healy and Amp AI Assistant
- ✅ **Repository URL**: Changed from placeholder to `https://github.com/trissylegs/canva-connect-rust`
- ✅ **Homepage URL**: Updated to correct GitHub repository
- ✅ **Description**: Added note about AI-generated code with Amp by Sourcegraph

## Testing
- [x] `cargo check` passes successfully
- [x] All metadata fields now contain accurate project information

## Closes
Fixes #6

## Type of Change
- [x] Bug fix (fixes placeholder values)
- [x] Documentation/metadata update

## Checklist
- [x] Changes follow existing code style and conventions
- [x] Cargo.toml validates correctly
- [x] No breaking changes to functionality
- [x] All tests pass (`cargo check`)