### PR TITLE
Security: Remove command line argument parsing from examples

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -20,8 +20,6 @@
 - `cargo run --example designs` - Run design API example (needs .env setup)
 - `cargo run --example folders` - Run folder organization example (needs .env setup)
 - `cargo run --example observability --features observability` - Run observability example with tracing
-- `cargo run --example asset_upload -- --file path/to/file` - Run with custom file path
-- `cargo run --example url_asset_upload -- --url "https://rustacean.net/assets/rustacean-flat-happy.png"` - Run with custom URL
 
 **Complete Examples for All 34 API Endpoints:**
 - `asset_upload` - Upload files as assets (3 endpoints: create_upload_job, get_upload_job, wait_for_upload_job)

--- a/examples/asset_upload.rs
+++ b/examples/asset_upload.rs
@@ -32,30 +32,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Get file path from .env file, command line arguments, or prompt
-    let file_path = if let Ok(path) = env::var("EXAMPLE_FILE_PATH") {
-        path
-    } else {
-        // Parse command line arguments for file path
-        let args: Vec<String> = env::args().collect();
-
-        let mut file_path = None;
-        let mut i = 1;
-        while i < args.len() {
-            if args[i] == "--file" && i + 1 < args.len() {
-                file_path = Some(args[i + 1].clone());
-                break;
-            }
-            i += 1;
-        }
-
-        file_path.unwrap_or_else(|| {
-            eprintln!("Error: File path not found.");
-            eprintln!("Please either:");
-            eprintln!("1. Set EXAMPLE_FILE_PATH in .env file, or");
-            eprintln!("2. Use: cargo run --example asset_upload -- --file path/to/image.png");
-            std::process::exit(1);
-        })
-    };
+    let file_path = env::var("EXAMPLE_FILE_PATH").unwrap_or_else(|_| {
+        eprintln!("ℹ️  Using default image: rustacean-flat-noshadow.png");
+        eprintln!("💡 To use a custom file, set EXAMPLE_FILE_PATH in your .env file");
+        "rustacean-flat-noshadow.png".to_string()
+    });
 
     // Create the client
     let client =

--- a/examples/url_asset_upload.rs
+++ b/examples/url_asset_upload.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|_| "CANVA_ACCESS_TOKEN environment variable not set")?;
 
     // Get URL from command line arguments or environment
-    let image_url = get_image_url_from_args_or_env()?;
+    let image_url = get_image_url_from_env()?;
 
     println!("🌐 Canva Connect API - URL Asset Upload Example");
     println!("================================================");
@@ -203,39 +203,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Extract command line arguments or environment variable for image URL
-fn get_image_url_from_args_or_env() -> Result<String, Box<dyn std::error::Error>> {
-    // First try environment variable
+/// Extract image URL from environment variable or use default
+fn get_image_url_from_env() -> Result<String, Box<dyn std::error::Error>> {
+    // Try environment variable first
     if let Ok(url) = env::var("IMAGE_URL") {
         return Ok(url);
     }
 
-    // Then try command line arguments
-    let args: Vec<String> = env::args().collect();
-
-    let mut i = 1;
-    while i < args.len() {
-        if args[i] == "--url" && i + 1 < args.len() {
-            return Ok(args[i + 1].clone());
-        }
-        i += 1;
-    }
-
-    // Show help if no URL provided
-    eprintln!("❌ No image URL provided!");
-    eprintln!();
-    eprintln!("Usage:");
-    eprintln!("  cargo run --example url_asset_upload -- --url \"https://rustacean.net/assets/rustacean-flat-happy.png\"");
-    eprintln!();
-    eprintln!("Or set environment variable:");
-    eprintln!("  IMAGE_URL=\"https://rustacean.net/assets/rustacean-flat-happy.png\"");
+    // Use default Rustacean image
+    let default_url = "https://rustacean.net/assets/rustacean-flat-happy.png";
+    eprintln!("ℹ️  Using default image: {default_url}");
+    eprintln!("💡 To use a custom URL, set IMAGE_URL in your .env file");
     eprintln!();
     eprintln!("Example Rustacean URLs to try:");
     eprintln!("  https://rustacean.net/assets/rustacean-flat-happy.png");
     eprintln!("  https://rustacean.net/assets/rustacean-flat-gesture.png");
     eprintln!("  https://rustacean.net/assets/cuddlyferris.png");
 
-    Err("No image URL provided".into())
+    Ok(default_url.to_string())
 }
 
 /// Extract filename from URL, with fallback


### PR DESCRIPTION
Addresses security vulnerability in issue #33 where command line arguments could expose sensitive information in process lists and shell history.

## Changes
- Remove command line argument parsing from asset_upload.rs and url_asset_upload.rs examples
- Examples now only accept input through environment variables (.env file)
- Add sensible defaults when no environment variables are set
- Update AGENT.md documentation

## Security Improvement
Examples now only use environment variables, eliminating exposure risk through:
- Process lists (ps aux)
- Shell history
- System logs

## Testing
✅ All tests pass
✅ Examples compile successfully
✅ CI checks pass

Fixes #33